### PR TITLE
Fix build on Python 2.7

### DIFF
--- a/docs/doxygen/doxyxml/text.py
+++ b/docs/doxygen/doxyxml/text.py
@@ -28,7 +28,7 @@ def is_string(txt):
     if isinstance(txt, str):
         return True
     try:
-        if isinstance(txt, str):
+        if isinstance(txt, unicode):
             return True
     except NameError:
         pass


### PR DESCRIPTION
An overzealous 2to3 conversion broke builds on Python 2.7. This patch works on both 2.7 and 3.